### PR TITLE
Add deploy scripts for clingo-lp

### DIFF
--- a/.github/conda.py
+++ b/.github/conda.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+'''
+Simple script to call conda build with the current revision and version.
+'''
+
+import argparse
+import subprocess
+import json
+from re import match
+import os
+
+NAME = 'clingo-lp'
+
+def get_build_number(channels, version):
+    '''
+    Get the next build number.
+    '''
+    try:
+        pkgs = json.loads(subprocess.check_output(['conda', 'search', '--json', '-c', channels[-1], NAME]))
+    except subprocess.CalledProcessError:
+        pkgs = {NAME: []}
+
+
+    build_number = -1
+    for pkg in pkgs.get(NAME, []):
+        if pkg['channel'].find(channels[-1]) >= 0 and pkg["version"] == version:
+            build_number = max(build_number, pkg['build_number'])
+
+    return build_number + 1
+
+def run():
+    '''
+    Compile and upload conda packages.
+    '''
+
+    parser = argparse.ArgumentParser(description='Build conda packages.')
+    parser.add_argument('--release', action='store_true', help='Build release packages.')
+    args = parser.parse_args()
+    if args.release:
+        label = None
+        channels = ['potassco', 'conda-forge']
+    else:
+        label = "dev"
+        channels = ['potassco', 'potassco/label/dev', 'conda-forge']
+
+    version = None
+    with open('setup.py') as fh:
+        for line in fh:
+            m = match(r'''[ ]*version[ ]*=[ ]*['"]([0-9]+\.[0-9]+\.[0-9]+)(\.post[0-9]+)?['"]''', line)
+            if m is not None:
+                version = m.group(1)
+    assert version is not None
+    assert version is not None
+    build_number = get_build_number(channels, version)
+
+    build_env = os.environ.copy()
+    build_env.pop("BUILD_RELEASE", "1" if args.release else None)
+    build_env["VERSION_NUMBER"] = version
+    build_env["BUILD_NUMBER"] = str(build_number)
+    if 'GITHUB_SHA' in os.environ:
+        build_env["BUILD_REVISION"] = os.environ['GITHUB_SHA']
+
+    recipe_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'conda')
+    options = ['conda', 'build']
+    if label is not None:
+        options.extend(['--label', label])
+
+    for c in channels:
+        options.extend(['-c', c])
+    options.append(recipe_path)
+
+    subprocess.call(options, env=build_env)
+
+if __name__ == '__main__':
+    run()

--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = 'clingo-lp' %}
+{% set dev = not environ.get('BUILD_RELEASE', false) %}
+{% set version = environ.get('VERSION_NUMBER') %}
+{% set revision = environ.get('GITHUB_SHA', 'wip') %}
+{% set build = environ.get('BUILD_NUMBER', "0") %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  path: ../..
+
+requirements:
+  host:
+  - python >=3.5
+  - pip
+  - clingo >=5.5.0
+  run:
+  - python >=3.5
+  - clingo >=5.5.0
+  - lpsolve55
+
+build:
+  number: {{ build }}
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points: ['clingoLP = clingolp.app:main_clingo']
+
+
+about:
+  home: https://potassco.org/
+  license: MIT
+  summary: clingo with theory propagator for linear programming
+  license_file: LICENSE
+  doc_url: https://potassco.org/
+  dev_url: https://github.com/potassco/clingoLP

--- a/.github/deploy.yml
+++ b/.github/deploy.yml
@@ -1,0 +1,59 @@
+# do not edit the workflows, they are generated from this file
+pip:
+    pure: True
+    version: |
+        version = None
+        with open('setup.py') as fh:
+            for line in fh:
+                m = match(r'''[ ]*version[ ]*=[ ]*['"]([0-9]+\.[0-9]+\.[0-9]+)(\.post[0-9]+)?['"]''', line)
+                if m is not None:
+                    version = m.group(1)
+    build_depends_release: |
+        python3 -m pip install --user clingo
+    build_depends_dev: |
+        python3 -m pip install --user --extra-index-url https://test.pypi.org/simple/ clingo
+
+conda:
+    package_name:
+        'clingo-lp'
+    os: 
+        - 'ubuntu-latest'
+    channels_release:
+        - 'potassco'
+        - 'conda-forge'
+    channels_dev:
+        - 'potassco'
+        - 'potassco/label/dev'
+        - 'conda-forge'
+    version: |
+        version = None
+        with open('setup.py') as fh:
+            for line in fh:
+                m = match(r'''[ ]*version[ ]*=[ ]*['"]([0-9]+\.[0-9]+\.[0-9]+)(\.post[0-9]+)?['"]''', line)
+                if m is not None:
+                    version = m.group(1)
+        assert version is not None
+    meta:
+      url: https://github.com/potassco/clingoLP/archive/v{{ version }}.tar.gz
+      git_url: https://github.com/potassco/clingoLP.git
+      requirements:
+        host:
+          - python >=3.5
+          - pip
+          - clingo >=5.5.0
+        run:
+          - python >=3.5
+          - clingo >=5.5.0
+          - lpsolve55
+      build:
+        noarch: python
+        script: 'python setup.py install --single-version-externally-managed --record record.txt'
+        entry_points:
+          - clingoLP = clingolp.app:main_clingo
+      about:
+        home: https://potassco.org/
+        license: MIT
+        summary: clingo with theory propagator for linear programming
+        license_file: LICENSE
+        doc_url: https://potassco.org/
+        dev_url: https://github.com/potassco/clingoLP

--- a/.github/pipsource.py
+++ b/.github/pipsource.py
@@ -1,0 +1,57 @@
+'''
+Script to build pip source package.
+'''
+
+import argparse
+from re import finditer, escape, match, sub, search
+from subprocess import check_call, check_output
+
+def adjust_version(url):
+    '''
+    Adjust version in setup.py.
+    '''
+    with open('setup.py') as fr:
+        setup = fr.read()
+
+    package_name = search(r'''name[ ]*=[ ]*['"]([^'"]*)['"]''', setup).group(1)
+    package_regex = package_name.replace('-', '[-_]')
+
+    pip = check_output(['curl', '-sL', '{}/{}'.format(url, package_name)]).decode()
+    version = None
+    with open('setup.py') as fh:
+        for line in fh:
+            m = match(r'''[ ]*version[ ]*=[ ]*['"]([0-9]+\.[0-9]+\.[0-9]+)(\.post[0-9]+)?['"]''', line)
+            if m is not None:
+                version = m.group(1)
+    assert version is not None
+
+    post = 0
+    for m in finditer(r'{}-{}\.tar\.gz'.format(package_regex, escape(version)), pip):
+        post = max(post, 1)
+
+    for m in finditer(r'{}-{}\.post([0-9]+)\.tar\.gz'.format(package_regex, escape(version)), pip):
+        post = max(post, int(m.group(1)) + 1)
+
+    for m in finditer(r'{}-{}\.post([0-9]+).*\.whl'.format(package_regex, escape(version)), pip):
+        post = max(post, int(m.group(1)))
+
+    with open('setup.py', 'w') as fw:
+        if post > 0:
+            fw.write(sub('version( *)=.*', 'version = \'{}.post{}\','.format(version, post), setup, 1))
+        else:
+            fw.write(sub('version( *)=.*', 'version = \'{}\','.format(version), setup, 1))
+
+def run():
+    parser = argparse.ArgumentParser(description='Build source package.')
+    parser.add_argument('--release', action='store_true', help='Build release package.')
+    args = parser.parse_args()
+    if args.release:
+        url = 'https://pypi.org/simple'
+    else:
+        url = 'https://test.pypi.org/simple'
+
+    adjust_version(url)
+    check_call(['python3', 'setup.py', 'sdist', 'bdist_wheel'])
+
+if __name__ == "__main__":
+    run()

--- a/.github/trigger.sh
+++ b/.github/trigger.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function list() {
+    curl \
+      -X GET \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/potassco/clingoLP/actions/workflows" \
+      -d "{\"ref\":\"ref\"}"
+}
+
+function dispatch() {
+    token=$(grep -A1 workflow_dispatch ~/.tokens | tail -n 1)
+    curl \
+      -u "rkaminsk:$token" \
+      -X POST \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/potassco/clingoLP/actions/workflows/$1/dispatches" \
+      -d "{\"ref\":\"$3\",\"inputs\":{\"wip\":\"$2\"${4:+,$4}}}"
+}
+
+branch=master
+wip=true
+
+case $1 in
+    list)
+        list
+        ;;
+    release)
+        if [[ $# < 2 ]]; then
+            echo "usage: trigger release REF"
+            exit 1
+        fi
+        wip=false
+        branch=$2
+        ;&
+    dev)
+        # .github/workflows/conda-dev.yml
+        dispatch 11630416 $wip $branch
+        # .github/workflows/pipsource.yml
+        dispatch 11627594 $wip $branch
+        ;;
+    *)
+        echo "usage: trigger {list,dev,release}"
+        exit 1
+        ;;
+esac

--- a/.github/workflows/conda-dev.yml
+++ b/.github/workflows/conda-dev.yml
@@ -1,0 +1,61 @@
+name: Deploy conda packages (wip)
+
+on:
+  workflow_dispatch:
+    inputs:
+      wip:
+        description: 'Publish work in progress package.'
+        required: false
+        default: 'true'
+
+jobs:
+  build:
+    name: deploy on ${{ matrix.os }} using python-${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        python-version: ['3.8']
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: setup miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        activate-environment: build
+
+    - name: Install prerequisites
+      shell: pwsh
+      run: |
+        conda config --set anaconda_upload yes
+        conda install conda-build anaconda-client
+
+    - name: print info
+      shell: pwsh
+      run: |
+        conda info
+        conda list
+
+    - name: publish conda package (wip)
+      if: ${{ github.event.inputs.wip == 'true' }}
+      shell: pwsh
+      run: |
+        python .github/conda.py
+      env:
+        ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+
+    - name: publish conda package (release)
+      if: ${{ github.event.inputs.wip == 'false' }}
+      shell: pwsh
+      run: |
+        python .github/conda.py --release
+      env:
+        ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/pipsource.yml
+++ b/.github/workflows/pipsource.yml
@@ -1,0 +1,60 @@
+name: Deploy pip source package (wip)
+
+on:
+  workflow_dispatch:
+    inputs:
+      wip:
+        description: 'Publish work in progress package.'
+        required: false
+        default: 'true'
+
+jobs:
+  build_packages:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install prerequisites
+      run: |
+        sudo apt-get install python3 python3-pip
+        pip3 install --user --upgrade --force-reinstall pip
+        python3 -m pip install --user --upgrade setuptools wheel
+
+    - name: Install prerequisites (wip)
+      if: ${{ github.event.inputs.wip == 'true' }}
+      run: |
+        python3 -m pip install --user --extra-index-url https://test.pypi.org/simple/ clingo
+
+    - name: Install prerequisites (release)
+      if: ${{ github.event.inputs.wip == 'false' }}
+      run: |
+        python3 -m pip install --user clingo
+
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Build source package (wip)
+      if: ${{ github.event.inputs.wip == 'true' }}
+      run: python3 .github/pipsource.py
+
+    - name: Publish package to TestPyPI (wip)
+      if: ${{ github.event.inputs.wip == 'true' }}
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: dist/
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Build source package (release)
+      if: ${{ github.event.inputs.wip == 'false' }}
+      run: python3 .github/pipsource.py --release
+
+    - name: Publish package to TestPyPI (release)
+      if: ${{ github.event.inputs.wip == 'false'}}
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN_RELEASE }}
+        packages_dir: dist/

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
 setup(
-    name='clingolp',
+    name='clingo-lp',
     version='0.1.1',
     url='http://github.com/potassco/clingoLP/',
     license='MIT',
-    description='',
+    description='clingo[LP] extends the ASP solver clingo with linear constraints as dealt with in Linear Programming (LP).',
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     author='Sebastian Schellhorn',


### PR DESCRIPTION
# TODO

- [x] add pip source package
  - [ ] <strike>add lpsolve as dependency</strike>
- [ ] <strike>add ppa package</strike>
- [x] add conda package

# Notes

I could only add a pip and conda packages due to the limited availability of lpsolve. There is no usable pip package for lpsolve. Users will have to install lpsolve or cplex manually when using pip. I did not add either of them as dependencies. I also could not provide a Ubuntu PPA package because the lp-solve package does not provide Python bindings. Conda is probably the best way to install and use clingo-lp.

In summary, we can now trigger deploys for pip and conda via github actions.